### PR TITLE
Potential fix for code scanning alert no. 2: Type confusion through parameter tampering

### DIFF
--- a/test-server.js
+++ b/test-server.js
@@ -47,6 +47,11 @@ app.post('/api/payments/create-charge', (req, res) => {
 app.post('/api/coinbase/webhook', express.raw({ type: 'application/json' }), (req, res) => {
   const signature = req.headers['x-cc-webhook-signature'];
   
+  if (typeof req.body !== 'string' && !Buffer.isBuffer(req.body)) {
+    console.error('Invalid body type received in Coinbase webhook:', typeof req.body);
+    res.status(400).send('Invalid request body');
+    return;
+  }
   console.log('Received Coinbase webhook:', {
     signature: signature ? 'present' : 'missing',
     bodyLength: req.body.length


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/OmniAuthor-Pro-2025/security/code-scanning/2](https://github.com/CreoDAMO/OmniAuthor-Pro-2025/security/code-scanning/2)

To fix the issue, we need to validate the type of `req.body` before accessing its `length` property. Specifically, we should check that `req.body` is either a string or a Buffer (as `express.raw` produces raw binary data). If the type is invalid, we should handle the error gracefully.

**Steps to fix:**
1. Add a type check for `req.body` to ensure it is either a string or a Buffer.
2. Log an appropriate message or return an error response if the type is invalid.
3. Ensure the fix does not alter the existing functionality of the endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
